### PR TITLE
Error handling for infinite loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,16 @@ Python implementation of Yung-Yu Chuang, Brian Curless, David H. Salesin, and Ri
 - numba > 0.30.1 (Not neccesary, but does give a 5x speedup)
 - matplotlib
 - opencv
+- sys
+- pathlib
 
 ### Running the demo
-- 'python bayesian_matting.py'
--  sigma (σ) fall off of gaussian weighting to local window
--  N size of window to construct local fg/bg clusters from
--  minN minimum number of known pixels in local window to proceed
+- 'python bayesian_matting.py gandalf.png gandalfTrimap.png'
+- sigma (σ) fall off of gaussian weighting to local window
+- N size of window to construct local fg/bg clusters from
+- minN minimum number of known pixels in local window to proceed
+- minN_reduction to reduce N by in event of infinite loop. May reduce accuracy
+- failure criteria percentage to know when to exit infinite loop
 
 
 ### Results

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Python implementation of Yung-Yu Chuang, Brian Curless, David H. Salesin, and Ri
 - opencv
 - sys
 - pathlib
+- argparse
 
 ### Running the demo
 - 'python bayesian_matting.py gandalf.png gandalfTrimap.png'
@@ -18,7 +19,6 @@ Python implementation of Yung-Yu Chuang, Brian Curless, David H. Salesin, and Ri
 - N size of window to construct local fg/bg clusters from
 - minN minimum number of known pixels in local window to proceed
 - minN_reduction to reduce N by in event of infinite loop. May reduce accuracy
-- failure criteria percentage to know when to exit infinite loop
 
 
 ### Results

--- a/bayesian_matting.py
+++ b/bayesian_matting.py
@@ -1,5 +1,7 @@
+import sys
+from pathlib import Path
 import numpy as np
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 import cv2
 from numba import jit 
 
@@ -141,8 +143,8 @@ def bayesian_matte(img, trimap, sigma=8, N=25, minN=10):
         Y, X = np.nonzero(unkpixels)
 
         for i in range(Y.shape[0]):
-            if n % 100 == 0:
-                print(n, nUnknown)
+            # if n % 100 == 0:
+                # print(n, nUnknown)
             y, x = Y[i], X[i]
             p = img[y, x]
             # Try cluster Fg, Bg in p's known neighborhood
@@ -187,19 +189,18 @@ def bayesian_matte(img, trimap, sigma=8, N=25, minN=10):
     return alpha
 
 
-def main():
-    img = scipy.misc.imread("gandalf.png")[:, :, :3]
-    trimap = scipy.misc.imread("gandalfTrimap.png", flatten='True')
+def main(img_path, trimap_path):
+    img = cv2.imread(Path(img_path))[:, :, :3]
+    trimap = cv2.imread(Path(trimap_path), cv2.IMREAD_GRAYSCALE)
     alpha = bayesian_matte(img, trimap)
     #scipy.misc.imsave('gandalfAlpha.png', alpha)
-    #plt.title("Alpha matte")
-    #plt.imshow(alpha, cmap='gray')
-    #plt.show()
+    plt.title("Alpha matte")
+    plt.imshow(alpha, cmap='gray')
+    plt.show()
 
 if __name__ == '__main__':
     import matplotlib.pyplot as plt
-    import scipy.misc
-    main()
+    main(sys.argv[0], sys.argv[1])
 
 
 

--- a/bayesian_matting.py
+++ b/bayesian_matting.py
@@ -190,8 +190,9 @@ def bayesian_matte(img, trimap, sigma=8, N=25, minN=10):
 
 
 def main(img_path, trimap_path):
-    img = cv2.imread(Path(img_path))[:, :, :3]
-    trimap = cv2.imread(Path(trimap_path), cv2.IMREAD_GRAYSCALE)
+    print(img_path)
+    img = cv2.imread(str(Path(img_path)))[:, :, :3]
+    trimap = cv2.imread(str(Path(trimap_path)), cv2.IMREAD_GRAYSCALE)
     alpha = bayesian_matte(img, trimap)
     #scipy.misc.imsave('gandalfAlpha.png', alpha)
     plt.title("Alpha matte")
@@ -200,7 +201,7 @@ def main(img_path, trimap_path):
 
 if __name__ == '__main__':
     import matplotlib.pyplot as plt
-    main(sys.argv[0], sys.argv[1])
+    main(sys.argv[1], sys.argv[2])
 
 
 

--- a/bayesian_matting.py
+++ b/bayesian_matting.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import numpy as np
 import cv2
 from numba import jit
+from argparse import ArgumentParser
 import warnings
 
 from orchard_bouman_clust import clustFunc
@@ -13,10 +14,10 @@ def matlab_style_gauss2d(shape=(3, 3), sigma=0.5):
     2D gaussian mask - should give the same result as MATLAB's
     fspecial('gaussian',[shape],[sigma])
     """
-    m, n = [(ss-1.)/2. for ss in shape]
-    y, x = np.ogrid[-m:m+1, -n:n+1]
-    h = np.exp(-(x*x + y*y)/(2.*sigma*sigma))
-    h[h < np.finfo(h.dtype).eps*h.max()] = 0
+    m, n = [(ss - 1.) / 2. for ss in shape]
+    y, x = np.ogrid[-m:m + 1, -n:n + 1]
+    h = np.exp(-(x * x + y * y) / (2. * sigma * sigma))
+    h[h < np.finfo(h.dtype).eps * h.max()] = 0
     sumh = h.sum()
     if sumh != 0:
         h /= sumh
@@ -28,15 +29,20 @@ def matlab_style_gauss2d(shape=(3, 3), sigma=0.5):
 @jit(nopython=True, cache=True)
 def get_window(m, x, y, N):
     h, w, c = m.shape
-    halfN = N//2
+    halfN = N // 2
     r = np.zeros((N, N, c))
-    xmin = max(0, x - halfN); xmax = min(w, x + (halfN+1))
-    ymin = max(0, y - halfN); ymax = min(h, y + (halfN+1))
-    pxmin = halfN - (x-xmin); pxmax = halfN + (xmax-x)
-    pymin = halfN - (y-ymin); pymax = halfN + (ymax-y)
+    xmin = max(0, x - halfN);
+    xmax = min(w, x + (halfN + 1))
+    ymin = max(0, y - halfN);
+    ymax = min(h, y + (halfN + 1))
+    pxmin = halfN - (x - xmin);
+    pxmax = halfN + (xmax - x)
+    pymin = halfN - (y - ymin);
+    pymax = halfN + (ymax - y)
 
     r[pymin:pymax, pxmin:pxmax] = m[ymin:ymax, xmin:xmax]
     return r
+
 
 @jit(nopython=True, cache=True)
 def solve(mu_F, Sigma_F, mu_B, Sigma_B, C, sigma_C, alpha_init, maxIter, minLike):
@@ -62,7 +68,7 @@ def solve(mu_F, Sigma_F, mu_B, Sigma_B, C, sigma_C, alpha_init, maxIter, minLike
     BMax = np.zeros(3)
     alphaMax = 0
     maxlike = - np.inf
-    invsgma2 = 1/sigma_C**2
+    invsgma2 = 1 / sigma_C ** 2
     for i in range(mu_F.shape[0]):
         mu_Fi = mu_F[i]
         invSigma_Fi = np.linalg.inv(Sigma_F[i])
@@ -75,12 +81,12 @@ def solve(mu_F, Sigma_F, mu_B, Sigma_B, C, sigma_C, alpha_init, maxIter, minLike
             lastLike = -1.7977e+308
             while True:
                 # solve for F,B
-                A11 = invSigma_Fi + I*alpha**2 * invsgma2
-                A12 = I*alpha*(1-alpha) * invsgma2
-                A22 = invSigma_Bj+I*(1-alpha)**2 * invsgma2
+                A11 = invSigma_Fi + I * alpha ** 2 * invsgma2
+                A12 = I * alpha * (1 - alpha) * invsgma2
+                A22 = invSigma_Bj + I * (1 - alpha) ** 2 * invsgma2
                 A = np.vstack((np.hstack((A11, A12)), np.hstack((A12, A22))))
-                b1 = invSigma_Fi @ mu_Fi + C*(alpha) * invsgma2
-                b2 = invSigma_Bj @ mu_Bj + C*(1-alpha) * invsgma2
+                b1 = invSigma_Fi @ mu_Fi + C * (alpha) * invsgma2
+                b2 = invSigma_Bj @ mu_Bj + C * (1 - alpha) * invsgma2
                 b = np.atleast_2d(np.concatenate((b1, b2))).T
 
                 X = np.linalg.solve(A, b)
@@ -88,13 +94,14 @@ def solve(mu_F, Sigma_F, mu_B, Sigma_B, C, sigma_C, alpha_init, maxIter, minLike
                 B = np.maximum(0, np.minimum(1, X[3:6]))
                 # solve for alpha
 
-                alpha = np.maximum(0, np.minimum(1, ((np.atleast_2d(C).T-B).T @ (F-B))/np.sum((F-B)**2)))[0,0]
+                alpha = np.maximum(0, np.minimum(1, ((np.atleast_2d(C).T - B).T @ (F - B)) / np.sum((F - B) ** 2)))[
+                    0, 0]
                 # # calculate likelihood
-                L_C = - np.sum((np.atleast_2d(C).T -alpha*F-(1-alpha)*B)**2) * invsgma2
-                L_F = (- ((F- np.atleast_2d(mu_Fi).T).T @ invSigma_Fi @ (F-np.atleast_2d(mu_Fi).T))/2)[0,0]
-                L_B = (- ((B- np.atleast_2d(mu_Bj).T).T @ invSigma_Bj @ (B-np.atleast_2d(mu_Bj).T))/2)[0,0]
+                L_C = - np.sum((np.atleast_2d(C).T - alpha * F - (1 - alpha) * B) ** 2) * invsgma2
+                L_F = (- ((F - np.atleast_2d(mu_Fi).T).T @ invSigma_Fi @ (F - np.atleast_2d(mu_Fi).T)) / 2)[0, 0]
+                L_B = (- ((B - np.atleast_2d(mu_Bj).T).T @ invSigma_Bj @ (B - np.atleast_2d(mu_Bj).T)) / 2)[0, 0]
                 like = (L_C + L_F + L_B)
-                #like = 0
+                # like = 0
 
                 if like > maxlike:
                     alphaMax = alpha
@@ -102,7 +109,7 @@ def solve(mu_F, Sigma_F, mu_B, Sigma_B, C, sigma_C, alpha_init, maxIter, minLike
                     FMax = F.ravel()
                     BMax = B.ravel()
 
-                if myiter >= maxIter or abs(like-lastLike) <= minLike:
+                if myiter >= maxIter or abs(like - lastLike) <= minLike:
                     break
 
                 lastLike = like
@@ -110,8 +117,12 @@ def solve(mu_F, Sigma_F, mu_B, Sigma_B, C, sigma_C, alpha_init, maxIter, minLike
     return FMax, BMax, alphaMax
 
 
-def bayesian_matte(img, trimap, sigma=8, N=25, minN=10, minN_reduction=0, failure_criteria=0.5):
-    img = img/255
+def bayesian_matte(img, trimap, sigma=8, N=25, minN=10, minN_reduction=0):
+    # check minN_reduction parameter
+    if minN_reduction >= minN:
+        raise ValueError("minN_reduction parameter must be less than minN")
+
+    img = img / 255
 
     h, w, c = img.shape
     alpha = np.zeros((h, w))
@@ -119,11 +130,11 @@ def bayesian_matte(img, trimap, sigma=8, N=25, minN=10, minN_reduction=0, failur
     fg_mask = trimap == 255
     bg_mask = trimap == 0
     unknown_mask = True ^ np.logical_or(fg_mask, bg_mask)
-    foreground = img*np.repeat(fg_mask[:, :, np.newaxis], 3, axis=2)
-    background = img*np.repeat(bg_mask[:, :, np.newaxis], 3, axis=2)
+    foreground = img * np.repeat(fg_mask[:, :, np.newaxis], 3, axis=2)
+    background = img * np.repeat(bg_mask[:, :, np.newaxis], 3, axis=2)
 
     gaussian_weights = matlab_style_gauss2d((N, N), sigma)
-    gaussian_weights = gaussian_weights/np.max(gaussian_weights)
+    gaussian_weights = gaussian_weights / np.max(gaussian_weights)
 
     alpha[fg_mask] = 1
     F = np.zeros(img.shape)
@@ -135,10 +146,6 @@ def bayesian_matte(img, trimap, sigma=8, N=25, minN=10, minN_reduction=0, failur
     nUnknown = np.sum(unknown_mask)
     unkreg = unknown_mask
 
-    # set condition to terminate in event of infinite loop
-    failure = failure_criteria * nUnknown
-    iteration_failure = 0
-
     kernel = np.ones((3, 3))
     while n < nUnknown:
         unkreg = cv2.erode(unkreg.astype(np.uint8), kernel, iterations=1)
@@ -147,8 +154,8 @@ def bayesian_matte(img, trimap, sigma=8, N=25, minN=10, minN_reduction=0, failur
         Y, X = np.nonzero(unkpixels)
 
         for i in range(Y.shape[0]):
-            # if n % 100 == 0:
-                # print(n, nUnknown)
+            if n % 100 == 0:
+                print(n, nUnknown)
             y, x = Y[i], X[i]
             p = img[y, x]
             # Try cluster Fg, Bg in p's known neighborhood
@@ -158,37 +165,37 @@ def bayesian_matte(img, trimap, sigma=8, N=25, minN=10, minN_reduction=0, failur
 
             # Take surrounding foreground pixels
             f_pixels = get_window(foreground, x, y, N)
-            f_weights = (a**2 * gaussian_weights).ravel()
+            f_weights = (a ** 2 * gaussian_weights).ravel()
 
-            f_pixels = np.reshape(f_pixels, (N*N, 3))
+            f_pixels = np.reshape(f_pixels, (N * N, 3))
             posInds = np.nan_to_num(f_weights) > 0
             f_pixels = f_pixels[posInds, :]
             f_weights = f_weights[posInds]
 
             # Take surrounding background pixels
             b_pixels = get_window(background, x, y, N)
-            b_weights = ((1-a)**2 * gaussian_weights).ravel()
+            b_weights = ((1 - a) ** 2 * gaussian_weights).ravel()
 
-            b_pixels = np.reshape(b_pixels, (N*N, 3))
+            b_pixels = np.reshape(b_pixels, (N * N, 3))
             posInds = np.nan_to_num(b_weights) > 0
             b_pixels = b_pixels[posInds, :]
             b_weights = b_weights[posInds]
 
             # if not enough data, return to it later...
             if len(f_weights) < minN or len(b_weights) < minN:
-                # could cause infinite loop. Add counter to track how often this condition continues
-                iteration_failure += 1
-                # if failure_criteria is met, adjust minN and retry. If that fails, terminate the program
-                if iteration_failure == failure:
-                    if minN >= (minN - minN_reduction):
+                # if end of loop has been reached and n is still < nUnknown, infinite loop will occur
+                if i == Y.shape[0] and n < nUnknown:
+                    # adjust minN, break loop, and retry. If that still fails, terminate the program
+                    if minN > (minN - minN_reduction):
                         minN -= 1
-                        iteration_failure = 0
+                        n = 1
                         warnings.warn(message="Infinte loop encountered. Reducing minN by 1 and retrying.",
                                       category=RuntimeWarning)
+                        break
                     else:
-                        raise RuntimeError("Terminating infinite loop based on failure_criteria, adjust input "
-                                           "parameters and retry.")
+                        raise RuntimeError("Terminating infinite loop. Adjust input parameters and retry.")
                 continue
+
             # Partition foreground and background pixels to clusters (in a weighted manner)
             mu_f, sigma_f = clustFunc(f_pixels, f_weights)
             mu_b, sigma_b = clustFunc(b_pixels, b_weights)
@@ -201,24 +208,36 @@ def bayesian_matte(img, trimap, sigma=8, N=25, minN=10, minN_reduction=0, failur
             alpha[y, x] = alphaT
             unknown_mask[y, x] = 0
             n += 1
-            iteration_failure = 0
 
     return alpha
 
 
-def main(img_path, trimap_path):
-    print(img_path)
-    img = cv2.imread(str(Path(img_path)))[:, :, :3]
-    trimap = cv2.imread(str(Path(trimap_path)), cv2.IMREAD_GRAYSCALE)
-    alpha = bayesian_matte(img, trimap)
-    #scipy.misc.imsave('gandalfAlpha.png', alpha)
+def main(img, trimap, sigma, N, minN, minN_reduction):
+    img = cv2.imread(str(Path(img)))[:, :, :3]
+    trimap = cv2.imread(str(Path(trimap)), cv2.IMREAD_GRAYSCALE)
+    alpha = bayesian_matte(img, trimap, sigma, N, minN, minN_reduction)
+    # scipy.misc.imsave('gandalfAlpha.png', alpha)
     plt.title("Alpha matte")
     plt.imshow(alpha, cmap='gray')
     plt.show()
 
+
 if __name__ == '__main__':
     import matplotlib.pyplot as plt
-    main(sys.argv[1], sys.argv[2])
 
+    # start parser
+    parser = ArgumentParser()
 
+    # add args
+    parser.add_argument('image', help="path to image to be segmented")
+    parser.add_argument('trimap', help="path to trimap of image")
+    parser.add_argument('-s', '--sigma', default=8, help="variance of gaussian for spatial weighting")
+    parser.add_argument('-n', '--N', default=25, help="pixel neighborhood size")
+    parser.add_argument('-mn', '--minN', default=10, help="minimum required foreground and background neighbors for "
+                                                          "optimization")
+    parser.add_argument('-red', '--minN_reduction', default=0, help="number of times to reduce minN if an infinite "
+                                                                    "loop is encountered")
 
+    args = parser.parse_args()
+    # call main with all args
+    main(args.image, args.trimap, args.sigma, args.N, args.minN, args.minN_reduction)


### PR DESCRIPTION
Main component is detection of an infinite loop and adding a retry method for the infinite loop encountered by some users in #5. Added integer parameter `minN_reduction` to `bayesian_matte()` that allows the user to decrease minN by 1 and retry for that many times when an infinite loop is detected. If this still fails, a runtime error is raised and the program terminates, suggesting to adjust input parameters.

Other changes include:
- reading in the image and trump using openCV.imread, as spicy.misc is depreciated.
- using argparse for command line interaction when calling `main()`

README has been updated to reflect changes.

